### PR TITLE
Turn off fragments rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = {
     'react/jsx-handler-names': 'error',
     'react/jsx-no-bind': 'error',
     'react/jsx-one-expression-per-line': 'off',
-    'react/jsx-fragments': 'error',
+    'react/jsx-fragments': 'off',
     'react/jsx-pascal-case': 'error',
     'react/jsx-props-no-multi-spaces': 'error',
     'react/jsx-sort-default-props': 'error',


### PR DESCRIPTION
Allow use of `<Fragment>` by importing `{ Fragment } from 'react'` and stop eslint from requiring the use of `<>`.

This is necessary to use fragments with Theme UI without importing the full React and use it with `React.Fragment`, as it doesn't support the shorthand `<>`. 