### PR TITLE
feat: add support for jest

### DIFF
--- a/.cz.json
+++ b/.cz.json
@@ -8,4 +8,3 @@
   "defaultBody": "",
   "defaultIssues": ""
 }
-

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
   ],
   rules: {
     semi: 'off',
-    'no-console': [ 'error', { allow: [ 'warn', 'error' ] } ],
+    'no-console': ['error', { allow: ['warn', 'error'] }],
     'react/boolean-prop-naming': 'error',
     'react/no-array-index-key': 'error',
     'react/no-set-state': 'error',
@@ -36,9 +36,15 @@ module.exports = {
     'react/style-prop-object': 'error',
     'react/void-dom-elements-no-children': 'error',
     'react/jsx-boolean-value': 'error',
-    'react/jsx-filename-extension': [ 'warn', { extensions: [ '.js', '.jsx', '.ts', '.tsx' ] } ],
+    'react/jsx-filename-extension': [
+      'warn',
+      { extensions: ['.js', '.jsx', '.ts', '.tsx'] },
+    ],
     'react/jsx-handler-names': 'error',
-    'react/jsx-no-bind': [ 'error', { allowArrowFunctions: true, allowFunctions: true } ],
+    'react/jsx-no-bind': [
+      'error',
+      { allowArrowFunctions: true, allowFunctions: true },
+    ],
     'react/jsx-one-expression-per-line': 'off',
     'react/jsx-fragments': 'off',
     'react/jsx-pascal-case': 'error',
@@ -51,7 +57,7 @@ module.exports = {
     'jsx-a11y/label-has-associated-control': [
       'error',
       {
-        controlComponents: [ 'Select', 'Input', 'TextArea', 'Textarea' ],
+        controlComponents: ['Select', 'Input', 'TextArea', 'Textarea'],
         depth: 3,
       },
     ],
@@ -65,7 +71,7 @@ module.exports = {
     react: {
       version: 'detect',
     },
-    linkComponents: [ { name: 'Link', linkAttribute: 'to' } ],
+    linkComponents: [{ name: 'Link', linkAttribute: 'to' }],
   },
   overrides: [
     {
@@ -73,7 +79,7 @@ module.exports = {
       env: { node: true },
       rules: {
         'simple-import-sort/sort': 'off',
-        'import/order': [ 'error', { 'newlines-between': 'always' } ],
+        'import/order': ['error', { 'newlines-between': 'always' }],
       },
     },
   ],

--- a/index.js
+++ b/index.js
@@ -1,17 +1,17 @@
 module.exports = {
+  parser: 'babel-eslint',
   env: {
     browser: true,
-    node: true,
     es6: true,
+    node: true,
   },
-  parser: 'babel-eslint',
   plugins: [
     'babel',
     'jsx-a11y',
     'react',
     'react-hooks',
-    'eslint-plugin-import',
-    'eslint-plugin-simple-import-sort',
+    'import',
+    'simple-import-sort',
   ],
   extends: [
     'eslint:recommended',
@@ -63,9 +63,13 @@ module.exports = {
     ],
     'simple-import-sort/sort': 'error',
     'sort-imports': 'off',
+    'import/order': 'off',
     'import/first': 'error',
     'import/newline-after-import': 'error',
     'import/no-duplicates': 'error',
+    'import/no-useless-path-segments': ['error', { commonjs: true }],
+    'import/export': 'error',
+    'import/no-mutable-exports': 'error',
   },
   settings: {
     react: {
@@ -80,6 +84,22 @@ module.exports = {
       rules: {
         'simple-import-sort/sort': 'off',
         'import/order': ['error', { 'newlines-between': 'always' }],
+      },
+    },
+    {
+      files: ['**/*.test.js'],
+      env: {
+        jest: true, // now **/*.test.js files' env has both es6 *and* jest
+      },
+      // Can't extend in overrides: https://github.com/eslint/eslint/issues/8813
+      // "extends": ["plugin:jest/recommended"]
+      plugins: ['jest'],
+      rules: {
+        'jest/no-disabled-tests': 'warn',
+        'jest/no-focused-tests': 'error',
+        'jest/no-identical-title': 'error',
+        'jest/prefer-to-have-length': 'warn',
+        'jest/valid-expect': 'error',
       },
     },
   ],

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "eslint": ">=5",
     "eslint-plugin-babel": ">=5",
     "eslint-plugin-jsx-a11y": ">=6.2.3",
+    "eslint-plugin-jest": ">=23",
     "eslint-plugin-react": ">=7",
     "eslint-plugin-react-hooks": ">=1",
     "eslint-plugin-import": ">=2",


### PR DESCRIPTION
This PR adds support for Jest so we get linting in tests too and also removes unnecessary warnings for some globals like `test`, etc.

This PR also includes a run with Prettier.

This PR also includes a sync/update with rules for import from @weahead/eslint-config-tool

Fixes https://trello.com/c/za8kU7xp